### PR TITLE
Feature: ToolBar add from template

### DIFF
--- a/components/EditorLayout/styled.js
+++ b/components/EditorLayout/styled.js
@@ -3,16 +3,18 @@ import styled from "styled-components";
 export const PageWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  height: 95vh;
+  height: 100vh;
+  padding: 20px;
 `;
 
 export const Header = styled.div`
-  height: 20%;
+  flex: 0;
 `;
 
 export const WindowsWrapper = styled.div`
   display: flex;
-  height: 80%;
+  flex: 1;
+  overflow: hidden;
 `;
 
 export const Window = styled.div`

--- a/components/EditorLayout/styled.js
+++ b/components/EditorLayout/styled.js
@@ -1,20 +1,23 @@
 import styled from "styled-components";
 
 export const PageWrapper = styled.div`
-  height: 56.25vw;
-  width: 99vw;
+  display: flex;
+  flex-direction: column;
+  height: 95vh;
 `;
 
-export const Header = styled.div``;
+export const Header = styled.div`
+  height: 20%;
+`;
 
 export const WindowsWrapper = styled.div`
   display: flex;
-  height: 100%;
+  height: 80%;
 `;
 
 export const Window = styled.div`
   margin: 10px;
   width: 50%;
   height: 100%;
-  overflow: scroll;
+  overflow: hidden;
 `;

--- a/components/Icon/index.js
+++ b/components/Icon/index.js
@@ -1,0 +1,18 @@
+import { Image } from "./styled";
+
+const Icon = ({ src, ...props }) => {
+  return <Image src={src} {...props} />;
+};
+
+const files = {
+  download: `/static/icons/download.svg`,
+  newTab: `/static/icons/newTab.svg`,
+  add: `/static/icons/add.svg`,
+};
+
+const Icons = Object.keys(files).reduce((acc, key) => {
+  acc[key] = (props) => <Icon src={files[key]} {...props} />;
+  return acc;
+}, {});
+
+export default Icons;

--- a/components/Icon/styled.js
+++ b/components/Icon/styled.js
@@ -1,0 +1,14 @@
+import styled, { css } from "styled-components";
+
+export const Image = styled.div`
+  width: 24px;
+  height: 24px;
+  display: inline-block;
+  cursor: pointer;
+  ${(props) =>
+    props.src &&
+    css`
+      background-image: url("${props.src}");
+      background-size: cover;
+    `};
+`;

--- a/components/PageTemplateList/index.js
+++ b/components/PageTemplateList/index.js
@@ -1,13 +1,19 @@
+import { Content, Item, Wrapper } from "./styled";
+
 const PageTemplateList = ({ templates, onClick }) => {
   const onClickFactory = (key) => {
-    return () => onClick(templates[key]);
+    return () => onClick(templates[key].raw);
   };
 
-  return Object.keys(templates)?.map((key, index) => (
-    <button key={index} onClick={onClickFactory(key)}>
-      {key}
-    </button>
-  ));
+  return (
+    <Wrapper>
+      {Object.keys(templates)?.map((key, index) => (
+        <Item key={index} onClick={onClickFactory(key)}>
+          <Content scrolling="no" srcDoc={templates[key].html} />
+        </Item>
+      ))}
+    </Wrapper>
+  );
 };
 
 export default PageTemplateList;

--- a/components/PageTemplateList/styled.js
+++ b/components/PageTemplateList/styled.js
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+
+  gap: 10px;
+  padding: 10px;
+  height: 100%;
+`;
+
+export const Item = styled.div`
+  cursor: pointer;
+  height: 100%;
+
+  &:hover {
+    border: #0969da solid 1px;
+  }
+`;
+
+export const Content = styled.iframe`
+  pointer-events: none;
+  height: 100%;
+
+  body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+  }
+`;

--- a/components/SlidesTextArea/styled.js
+++ b/components/SlidesTextArea/styled.js
@@ -12,7 +12,7 @@ export const TextAreaWrapper = styled.div`
   position: relative;
   width: 100%;
   padding-top: 56.25%;
-
+  margin-bottom: 10px;
   & > div:first-child {
     position: absolute;
     top: 0;

--- a/components/SlidesTextArea/styled.js
+++ b/components/SlidesTextArea/styled.js
@@ -4,6 +4,8 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0px 10.25px;
+  overflow: auto;
+  height: 100%;
 `;
 
 export const TextAreaWrapper = styled.div`

--- a/containers/PageTemplateList/index.js
+++ b/containers/PageTemplateList/index.js
@@ -9,14 +9,20 @@ const PageTemplateListContainer = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    dispatch(fetchTemplates());
+    if (!templates) dispatch(fetchTemplates());
   }, []);
 
   const onClick = (markdown) => {
     dispatch(addPage({ markdown }));
   };
 
-  return <PageTemplateList templates={templates} onClick={onClick} />;
+  return (
+    <>
+      {templates && (
+        <PageTemplateList templates={templates} onClick={onClick} />
+      )}
+    </>
+  );
 };
 
 export default PageTemplateListContainer;

--- a/containers/Slides/index.js
+++ b/containers/Slides/index.js
@@ -1,19 +1,11 @@
 import Slides from "components/Slides";
-import { download } from "helpers/file";
-import { openHtmlWindow } from "helpers/window";
 import { useSelector } from "react-redux";
 
 const SlidesContainer = () => {
   const { html } = useSelector((state) => state.pages);
 
   if (!html) return null;
-  return (
-    <>
-      <button onClick={() => openHtmlWindow(html)}>Preview</button>
-      <button onClick={() => download("slide", html)}>Download</button>
-      <Slides html={html} />
-    </>
-  );
+  return <Slides html={html} />;
 };
 
 export default SlidesContainer;

--- a/containers/ToolBar/index.js
+++ b/containers/ToolBar/index.js
@@ -18,14 +18,18 @@ const Tools = {
 
 const ToolBar = () => {
   const { html } = useSelector((state) => state.pages);
-  const [type, setType] = useState(TOOL_TYPE.none);
+  const [type, setType] = useState(TOOL_TYPE.templates);
+
+  const setTool = (newType) => {
+    if (newType === type) setType(TOOL_TYPE.none);
+    else setType(newType);
+  };
 
   const Tool = Tools[type] || null;
-
   return (
     <Wrapper>
       <IconList>
-        <Icon.add onClick={() => setType(TOOL_TYPE.templates)} />
+        <Icon.add onClick={() => setTool(TOOL_TYPE.templates)} />
         {html && <Icon.download onClick={() => download("slide", html)} />}
         {html && <Icon.newTab onClick={() => openHtmlWindow(html)} />}
       </IconList>

--- a/containers/ToolBar/index.js
+++ b/containers/ToolBar/index.js
@@ -1,0 +1,37 @@
+import Icon from "components/Icon";
+import PageTemplateList from "containers/PageTemplateList";
+import { download } from "helpers/file";
+import { openHtmlWindow } from "helpers/window";
+import { useState } from "react";
+import { useSelector } from "react-redux";
+
+import { IconList, Wrapper } from "./styled";
+
+const TOOL_TYPE = {
+  none: "none",
+  templates: "templates",
+};
+
+const Tools = {
+  templates: () => <PageTemplateList />,
+};
+
+const ToolBar = () => {
+  const { html } = useSelector((state) => state.pages);
+  const [type, setType] = useState(TOOL_TYPE.none);
+
+  const Tool = Tools[type] || null;
+
+  return (
+    <Wrapper>
+      <IconList>
+        <Icon.add onClick={() => setType(TOOL_TYPE.templates)} />
+        {html && <Icon.download onClick={() => download("slide", html)} />}
+        {html && <Icon.newTab onClick={() => openHtmlWindow(html)} />}
+      </IconList>
+      {Tool && <Tool />}
+    </Wrapper>
+  );
+};
+
+export default ToolBar;

--- a/containers/ToolBar/styled.js
+++ b/containers/ToolBar/styled.js
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const IconList = styled.div`
+  display: flex;
+  padding: 10px;
+  gap: 10px;
+  justify-content: center;
+`;

--- a/pages/api/templates/data.js
+++ b/pages/api/templates/data.js
@@ -19,11 +19,17 @@ const innerPage = `
 `;
 
 const images = `
-# Images Alignment
+<style>
+section > p  {
+  display:flex;
+}
+</style>
 
-![left:33% fit](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
-![right:33% fit](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
-![left:33% fit](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+# CSS Style
+
+![](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+![](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+
 `;
 
 const codeblock = `

--- a/pages/api/templates/data.js
+++ b/pages/api/templates/data.js
@@ -20,6 +20,10 @@ const innerPage = `
 
 const images = `
 # Images Alignment
+
+![left:33% fit](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+![right:33% fit](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+![left:33% fit](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
 `;
 
 const codeblock = `
@@ -38,29 +42,6 @@ const codeblock = `
     transform: rotate(90deg);
     pointer-events:none;
 }
-
-#closeButton{
-    width:24px;
-    height:24px;
-    background:red;
-    text-align: center;
-    width:100%;
-}
-
-#focusDetector:focus-within #dropDownMenu{
-    display:flex;
-}
-#dropDownMenu{
-    display:none;
-    flex-direction:column;
-    width: fit-content;
-    background:gray;
-}
-
-#itemsWrapper{
-    background:yellow;
-}
-
 .item{
     padding:10px
 }
@@ -77,106 +58,89 @@ const table = `
 |M|README.md||
 |A|lib/isomorphic-git.ts||
 |M|package.json||
-|A|pages/isomorphic-git/index.tsx||
-|M|yarn.lock||
-|M|.github/workflows/GithubCICD.yml||
-|M|.gitignore||
-|M|README.md||
-|A|lib/isomorphic-git.ts||
-|M|package.json||
-|A|pages/isomorphic-git/index.tsx||
-|M|yarn.lock||
-|M|.github/workflows/GithubCICD.yml||
-|M|.gitignore||
-|M|README.md||
-|A|lib/isomorphic-git.ts||
-|M|package.json||
-|A|pages/isomorphic-git/index.tsx||
-|M|yarn.lock||
 `;
 
-const sequenceDiagram = `
-# Mermaid diagram - sequenceDiagram
-  
+const mermaidWrapper = (name, markdown) => {
+  return `
+# Mermaid diagram - ${name}
 \`\`\`mermaid
-sequenceDiagram
-        
-    Note left of UI: onClick
-    par Call Reducer
-        UI->>Redux: 1.dispatch(ACTION_LOAD_DATA)
-    and Call Redux-saga
-        UI->>Redux-saga: 1.dispatch(ACTION_LOAD_DATA)
-    end
-    
-    Redux->>UI: 2.loading=true
-    
-    opt Need Current State
-        Redux-saga-->>+Redux: 3.yield select(state=>state)
-        Redux-->>-Redux-saga: 4.data
-    end
-    
-    Redux-saga->>+Server: 5.yield call(api)
-    Server-->>-Redux-saga: 6.response
-    
-    alt SUCCESS
-        Redux-saga->>Redux: 7.yield put(ACTION_LOAD_DATA_SUCCESS)
-        Redux->>UI: 8.loading=false, data
-    else FAIL
-        Redux-saga->>Redux: 7.yield put(ACTION_LOAD_DATA_FAIL)
-        Redux->>UI: 8.loading=false, error message 
-    end
+${markdown}
 \`\`\`
-`;
+    `;
+};
 
-const gantt = `
-# Mermaid diagram - gantt
-  
-\`\`\`mermaid
-gantt
-    title  
-    dateFormat  YYYY-MM-DD
-    excludes Sunday, Saturday
-    section Setup
-    project setup   :a1, 2022-11-01, 1d
+// all mermaid templates are provided by https://github.com/mermaid-js/mermaid
+const mermaidMarkdown = {
+  sequenceDiagram: `
+    sequenceDiagram
+        Alice->>John: Hello John, how are you?
+        loop Healthcheck
+            John->>John: Fight against hypochondria
+        end
+        Note right of John: Rational thoughts!
+        John-->>Alice: Great!
+        John->>Bob: How about you?
+        Bob-->>John: Jolly good!
+    `,
+  gantt: `
+    gantt
+        section Section
+        Completed :done,    des1, 2014-01-06,2014-01-08
+        Active        :active,  des2, 2014-01-07, 3d
+        Parallel 1   :         des3, after des1, 1d
+        Parallel 2   :         des4, after des1, 1d
+        Parallel 3   :         des5, after des3, 1d
+        Parallel 4   :         des6, after des4, 1d
+    `,
+  flowchart: `
+    flowchart LR
 
-    section Functions
-        Spotify API         :c1, 2022-11-01  , 1d
+        A[Hard] -->|Text| B(Round)
+        B --> C{Decision}
+        C -->|One| D[Result 1]
+        C -->|Two| E[Result 2]
+    `,
+  classDiagram: `
+    classDiagram
+        Class01 <|-- AveryLongClass : Cool
+        <<Interface>> Class01
+        Class09 --> C2 : Where am I?
+        Class09 --* C3
+        Class09 --|> Class07
+        Class07 : equals()
+        Class07 : Object[] elementData
+        Class01 : size()
+        Class01 : int chimp
+        Class01 : int gorilla
+        class Class10 {
+        <<service>>
+        int id
+        size()
+        }
+    `,
+  stateDiagram: `
+    stateDiagram-v2
+        [*] --> Still
+        Still --> [*]
+        Still --> Moving
+        Moving --> Still
+        Moving --> Crash
+        Crash --> [*]
+  `,
+  piechart: `
+    pie
+        "Dogs" : 386
+        "Cats" : 85.9
+        "Rats" : 15
+  `,
+};
 
-        Show categories             :c2, after c1  , 1d
-        Show musics                 :c3, after c2  , 1d
-        Change category             :c6, after c2  , 1d
-        Music preview               :c4, after b3  , 1d
-        Dribbble cover              :c5, after b3  , 1d
-
-    section CSS Layouts
-        Why us                              :b1, after c1  , 1d
-        Plan                                :b4, after c1  , 1d
-        Categories                  :b5, after c1  , 1d
-        Banner                                  :b2, after b1  , 1d
-        Musics                       :b6, after b1  , 1d
-        Header                                      :b3, after b2  , 1d
-        Footer                                      :b7, after b2  , 1d
-        User experience                             :b8, after b2  , 1d
-        Error/Loading                               :b9, after b3  , 1d
-
-
-    section enhance
-    debug               :d1, after c5  , 3d
-
-\`\`\`
-`;
-
-const flowchart = `
-# Mermaid diagram - flowchart
-\`\`\`mermaid
-graph TD;
-    A-->B;
-    A-->C;
-    B-->D;
-    C-->D;
-
-\`\`\`
-`;
+const mermaidTemplates = Object.keys(mermaidMarkdown).reduce((dict, key) => {
+  return {
+    ...dict,
+    [key]: mermaidWrapper(key, mermaidMarkdown[key]),
+  };
+}, {});
 
 export default {
   cover,
@@ -184,7 +148,5 @@ export default {
   images,
   codeblock,
   table,
-  sequenceDiagram,
-  gantt,
-  flowchart,
+  ...mermaidTemplates,
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,12 @@
 import EditorLayout from "containers/EditorLayout";
-import PageTemplateListContainer from "containers/PageTemplateList";
 import SlidesContainer from "containers/Slides";
 import SlidesTextAreaContainer from "containers/SlidesTextArea";
+import ToolBar from "containers/ToolBar";
 
 export default function App() {
   return (
     <EditorLayout
-      toolBar={<PageTemplateListContainer />}
+      toolBar={<ToolBar />}
       textEditor={<SlidesTextAreaContainer />}
       slidPreview={<SlidesContainer />}
     />

--- a/redux/reducers/pages.js
+++ b/redux/reducers/pages.js
@@ -8,7 +8,7 @@ import produce from "immer";
 const initialState = {
   html: null,
   pages: [],
-  templates: [],
+  templates: null,
 };
 
 const pages = (state = initialState, action) =>

--- a/redux/sagas/pages.js
+++ b/redux/sagas/pages.js
@@ -63,13 +63,22 @@ function* editPage({ markdown, id }) {
 }
 
 function* fetchTemplates() {
-  const { templates } = yield call(pages.fetchTemplates);
-  if (templates) {
-    yield put({
-      type: ACTION_FETCH_PAGE_TEMPLATES_SUC,
-      payload: templates,
-    });
+  const { templates: raws } = yield call(pages.fetchTemplates);
+  const keys = Object.keys(raws);
+
+  const templates = {};
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    templates[key] = {
+      raw: raws[key],
+      html: yield call(pareMarkdownToHtml, raws[key]),
+    };
   }
+
+  yield put({
+    type: ACTION_FETCH_PAGE_TEMPLATES_SUC,
+    payload: templates,
+  });
 }
 
 function* convertPageToHtml(pages) {

--- a/static/icons/add.svg
+++ b/static/icons/add.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+
+<title/>
+
+<g id="Complete">
+
+<g id="add-square">
+
+<g>
+
+<rect data-name="--Rectangle" fill="none" height="20" id="_--Rectangle" rx="2" ry="2" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" width="20" x="2" y="2"/>
+
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="15.5" x2="8.5" y1="12" y2="12"/>
+
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="15.5" y2="8.5"/>
+
+</g>
+
+</g>
+
+</g>
+
+</svg>

--- a/static/icons/download.svg
+++ b/static/icons/download.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+
+<title/>
+
+<g id="Complete">
+
+<g id="download">
+
+<g>
+
+<path d="M3,12.3v7a2,2,0,0,0,2,2H19a2,2,0,0,0,2-2v-7" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+
+<g>
+
+<polyline data-name="Right" fill="none" id="Right-2" points="7.9 12.3 12 16.3 16.1 12.3" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+
+<line fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" x1="12" x2="12" y1="2.7" y2="14.2"/>
+
+</g>
+
+</g>
+
+</g>
+
+</g>
+
+</svg>

--- a/static/icons/newTab.svg
+++ b/static/icons/newTab.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" >
+<path d="M0 0h48v48H0z" fill="none"/>
+<g id="Shopicon">
+	<polygon points="44,30 40,30 40,38 8,38 8,10 20,10 20,6 4,6 4,42 44,42 	"/>
+	<polygon points="26,26.828 40,12.828 40,24 44,24 44,6 26,6 26,10 37.172,10 23.172,24 	"/>
+</g>
+</svg>


### PR DESCRIPTION
## Changed 

- Add `ToolBar` (Templates, Download, New Tab)
- Add markdown examples : mermaid, css
- Add `Icon` to show `.svg`

## Snapshot

![image](https://user-images.githubusercontent.com/27216619/235353557-5753037f-b91f-49fc-9fbb-ea3744db169b.png)
