### PR TITLE
Feature: read old markdowns data

### DIFF
--- a/apps/editor/index.js
+++ b/apps/editor/index.js
@@ -1,8 +1,11 @@
+import { SHARE_BASE64_MARKDOWN_KEY } from "constants/share";
 import HtmlViewer from "features/HtmlViewer";
 import Layout from "features/Layout";
 import MarkdownEditor from "features/MarkdownEditor";
 import ToolBar from "features/Toolbar";
 import { pagesToMarkdown } from "helpers/markdown";
+import uuid from "helpers/uuid";
+import useBase64FromQueryString from "hooks/useQueryString";
 import { useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -10,6 +13,7 @@ import {
   deletePage,
   editPage,
   fetchTemplates,
+  setPages,
 } from "redux/actions/pages";
 
 const Editor = ({ markdowns, toolbar }) => {
@@ -39,9 +43,32 @@ const Editor = ({ markdowns, toolbar }) => {
   );
 };
 
+const useQueryStringToRedux = () => {
+  const { pages, html } = useBase64FromQueryString(SHARE_BASE64_MARKDOWN_KEY);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (pages) {
+      dispatch(
+        setPages({
+          payload: {
+            pages: pages.map((markdown) => ({
+              id: uuid(),
+              markdown,
+            })),
+            html,
+          },
+        }),
+      );
+    }
+  }, [pages, html, dispatch]);
+};
+
 const EditorReduxWrapper = () => {
   const dispatch = useDispatch();
   const { pages, html, templates } = useSelector((state) => state.pages);
+
+  useQueryStringToRedux();
 
   useEffect(() => {
     if (!templates) dispatch(fetchTemplates());

--- a/apps/viewer/index.js
+++ b/apps/viewer/index.js
@@ -1,28 +1,9 @@
+import { SHARE_BASE64_MARKDOWN_KEY } from "constants/share";
 import HtmlViewer from "features/HtmlViewer";
-import { decodeString } from "helpers/pako";
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-
-import { pareMarkdownToHtml } from "../../helpers/markdown";
+import useBase64FromQueryString from "hooks/useQueryString";
 
 const Viewer = () => {
-  const [html, setHTML] = useState("");
-  const router = useRouter();
-  const {
-    query: { data },
-  } = router;
-
-  useEffect(() => {
-    try {
-      if (data) {
-        const decoded = decodeString(data);
-        pareMarkdownToHtml(decoded).then(setHTML);
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  }, [data]);
-
+  const { html } = useBase64FromQueryString(SHARE_BASE64_MARKDOWN_KEY);
   return <HtmlViewer html={html} />;
 };
 

--- a/constants/share.js
+++ b/constants/share.js
@@ -1,0 +1,2 @@
+export const SHARE_BASE64_MARKDOWN_KEY = "data";
+export const SHARE_PAGE = "share";

--- a/features/Toolbar/index.js
+++ b/features/Toolbar/index.js
@@ -1,4 +1,5 @@
 import Icon from "components/Icon";
+import { SHARE_BASE64_MARKDOWN_KEY, SHARE_PAGE } from "constants/share";
 import PageTemplateList from "features/Toolbar/PageTemplateList";
 import { download } from "helpers/file";
 import { encodeString } from "helpers/pako";
@@ -49,7 +50,7 @@ const ToolBar = ({
 
   const shareLink = (markdown) => {
     const encoded = encodeString(markdown);
-    const url = `${window.location}/share?data=${encoded}`;
+    const url = `./${SHARE_PAGE}?${SHARE_BASE64_MARKDOWN_KEY}=${encoded}`;
     window.open(url, "_blank");
   };
 

--- a/helpers/markdown.js
+++ b/helpers/markdown.js
@@ -80,9 +80,14 @@ const getHTMLFromTemplate = (body, style) => {
   return html;
 };
 
+const BREAK_PAGE_SYMBOL = "\n\n---\n\n";
+export const markdownToPages = (markdown) => {
+  return markdown.split(BREAK_PAGE_SYMBOL);
+};
+
 export const pagesToMarkdown = (pages) => {
   const markdowns = pages.map((data) => data?.markdown);
-  const wholeMarkdown = markdowns.join("\n\n---\n\n");
+  const wholeMarkdown = markdowns.join(BREAK_PAGE_SYMBOL);
   return wholeMarkdown;
 };
 

--- a/helpers/uuid.js
+++ b/helpers/uuid.js
@@ -1,0 +1,3 @@
+import { v4 as uuid } from "uuid";
+
+export default uuid;

--- a/hooks/useQueryString.js
+++ b/hooks/useQueryString.js
@@ -1,0 +1,29 @@
+import { decodeString } from "helpers/pako";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { markdownToPages, pareMarkdownToHtml } from "../helpers/markdown";
+
+const useBase64FromQueryString = (key) => {
+  const [html, setHTML] = useState("");
+  const [pages, setPages] = useState(null);
+  const router = useRouter();
+  const data = router.query[key];
+
+  useEffect(() => {
+    try {
+      if (data) {
+        const decoded = decodeString(data);
+        const pages = markdownToPages(decoded);
+        setPages(pages);
+        pareMarkdownToHtml(decoded).then(setHTML);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }, [data]);
+
+  return { html, pages };
+};
+
+export default useBase64FromQueryString;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-dom": "18.2.0",
     "react-redux": "^8.0.5",
     "redux-saga": "^1.2.1",
-    "styled-components": "^5.3.6"
+    "styled-components": "^5.3.6",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",

--- a/redux/actions/pages.js
+++ b/redux/actions/pages.js
@@ -1,5 +1,6 @@
 import {
   ACTION_ADD_SLIDE_PAGE,
+  ACTION_ADD_SLIDE_PAGE_SUC,
   ACTION_DELETE_SLIDE_PAGE,
   ACTION_EDIT_SLIDE_PAGE,
   ACTION_FETCH_PAGE_TEMPLATES,
@@ -10,3 +11,5 @@ export const addPage = actionFactory(ACTION_ADD_SLIDE_PAGE);
 export const deletePage = actionFactory(ACTION_DELETE_SLIDE_PAGE);
 export const fetchTemplates = actionFactory(ACTION_FETCH_PAGE_TEMPLATES);
 export const editPage = actionFactory(ACTION_EDIT_SLIDE_PAGE);
+
+export const setPages = actionFactory(ACTION_ADD_SLIDE_PAGE_SUC);

--- a/redux/sagas/pages.js
+++ b/redux/sagas/pages.js
@@ -9,16 +9,10 @@ import {
   ACTION_FETCH_PAGE_TEMPLATES,
   ACTION_FETCH_PAGE_TEMPLATES_SUC,
 } from "constants/pages";
+import uuid from "helpers/uuid";
 import { call, put, select, takeEvery } from "redux-saga/effects";
 
 import { pagesToMarkdown, pareMarkdownToHtml } from "../../helpers/markdown";
-
-const newId = (() => {
-  let counter = 0;
-  return () => {
-    return counter++;
-  };
-})();
 
 function* addPage({ markdown }) {
   const { pages } = yield select((state) => state.pages);
@@ -27,7 +21,7 @@ function* addPage({ markdown }) {
     ...pages,
     {
       markdown,
-      id: newId(),
+      id: uuid(),
     },
   ];
   const html = yield call(convertPageToHtml, newPages);


### PR DESCRIPTION
### Changed

- Edit now will load `base64 markdown` from query string of url.
- Use `uuid` package for page's id. 