### PR TITLE
Fix: mobile style

### DIFF
--- a/constants/RWD.js
+++ b/constants/RWD.js
@@ -1,6 +1,6 @@
 export const mobile = (text) => {
   return `
-    @media (max-width: 1200px) {
+    @media only screen and (orientation: portrait) {
         ${text}
     }
     `;

--- a/features/Layout/styled.js
+++ b/features/Layout/styled.js
@@ -2,6 +2,7 @@ import { mobile } from "constants/RWD";
 import styled from "styled-components";
 
 export const PageWrapper = styled.div`
+  background-color: white;
   display: flex;
   flex-direction: row;
   height: 100vh;


### PR DESCRIPTION
### Changed

- Set `background-color: white`
- Change RWD condition from `max-width:1200px` to `orientation: portrait`

### Snapshots

![image](https://github.com/yushaing-frontend/Markdown-Slides-Editor/assets/27216619/aa6a350d-4df1-4531-8342-248078d215ec)

![image](https://github.com/yushaing-frontend/Markdown-Slides-Editor/assets/27216619/96ac3f42-154e-4e69-8f7d-db0d3c9c2801)

